### PR TITLE
Make JSON feed full width

### DIFF
--- a/classes/lifecycle/trigger.php
+++ b/classes/lifecycle/trigger.php
@@ -136,7 +136,12 @@ class trigger extends base_automatic {
 
     public function extend_add_instance_form_definition($mform) {
         // To enter the student course restriction feed url.
-        $mform->addElement('text', 'courserestrictionfeed', get_string('courserestrictionfeed', 'tool_lcjsontrigger'));
+        $mform->addElement(
+            'text',
+            'courserestrictionfeed',
+            get_string('courserestrictionfeed', 'tool_lcjsontrigger'),
+            ['style' => 'width: 100%']
+        );
         $mform->setType('courserestrictionfeed', PARAM_URL);
         $mform->addRule('courserestrictionfeed', get_string('required'), 'required', null, 'client');
         $mform->addHelpButton('courserestrictionfeed', 'courserestrictionfeed', 'tool_lcjsontrigger');


### PR DESCRIPTION
Couldn't really find any other way to do this, this will add `style="width: 100%"` to the element. Tried `['class' => 'w-100']` that didn't work. Here is the full html element:
```
<input 
    type="text" 
    class="form-control is-invalid"
    name="courserestrictionfeed" 
    id="id_courserestrictionfeed" 
    value="" 
    aria-required="true" 
    style="width: 100%"
    data-initial-value=""
    aria-describedby="id_error_courserestrictionfeed"
    aria-invalid="true"
/>
```

![image](https://github.com/user-attachments/assets/d47a6d41-18a9-445e-95ae-05d6e8b26ce3)

